### PR TITLE
FIX swagger file - schema ref was broken

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -44,8 +44,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Temperatura
-              "
+              $ref: "#/definitions/Temperatura"
         "400":
           description: "Bad Input Parameter"
 


### PR DESCRIPTION
When you try to use the endpoint `/celsius/{valor}/fahrenheit` it shows this error:
<img width="1413" alt="Screen Shot 2021-06-29 at 12 08 09" src="https://user-images.githubusercontent.com/9124801/123822720-eb755880-d8d2-11eb-8b3b-88b2dfcba2cb.png">
